### PR TITLE
move logging around so the output is the same between playing a trace…

### DIFF
--- a/eudoxia/simulator.py
+++ b/eudoxia/simulator.py
@@ -181,6 +181,8 @@ def run_simulator(param_input: Union[str, Dict], workload: Workload = None) -> S
         root_logger._elapsed_secs = tick_number / ticks_per_second
         
         new_pipelines: List[Pipeline] = workload.run_one_tick()
+        for p in new_pipelines:
+            logger.info(f"Pipeline arrived with Priority {p.priority} and {len(p.values)} op(s)")
         suspensions, assignments = scheduler.run_one_tick(executor_failures, new_pipelines)
         executor_failures = executor.run_one_tick(suspensions, assignments)
 

--- a/eudoxia/utils/dag.py
+++ b/eudoxia/utils/dag.py
@@ -26,6 +26,9 @@ class DAG[T: Node]:
         self.roots = [] # list of root nodes (nodes with no parents)
         self.iter = None
 
+    def __len__(self):
+        return len(self.node_ids)
+
     def __iter__(self):
         self.iter = DAGIterator(self)
         return self.iter

--- a/eudoxia/workload/workload.py
+++ b/eudoxia/workload/workload.py
@@ -156,7 +156,6 @@ class WorkloadGenerator(Workload):
                 op = Operator()
                 seg = self.generate_query_segment()
                 op.add_segment(seg)
-                logger.info(f"Pipeline generated with Priority {Priority(priority)} and 1 op")
                 p.values.add_node(op)
             else:
                 ops = []
@@ -184,7 +183,6 @@ class WorkloadGenerator(Workload):
                             op.add_segment(seg)
                         prev_seg = seg
                     ops.append(op)
-                logger.info(f"Pipeline generated with Priority {Priority(priority)} and {curr_num_ops} ops")
 
                 # Pipeline is all operators in a linked list. First call has only
                 # one argument as it has no parent. all others have parent that is


### PR DESCRIPTION
… or generating on the fly